### PR TITLE
SCUMM HE: Fixed crash when generating map

### DIFF
--- a/engines/scumm/he/moonbase/map_spiff.cpp
+++ b/engines/scumm/he/moonbase/map_spiff.cpp
@@ -337,20 +337,24 @@ void SpiffGenerator::errorCorrection() {
 			if (mapCorner[x][y] == HIGH) {
 				for (dy = -1; dy <= 1; ++dy) {
 					tempY = y + dy;
-					if (tempY == totalMapSizeG)
+					if (tempY == totalMapSizeG) {
 						tempY = 0;
-					else if (tempY == -1)
+					} else if (tempY == -1) {
 						tempY = totalMapSizeG - 1;
-				}
+					}
 
-				for (dx = -1; dx <= 1; ++dx) {
-					tempX = x + dx;
-					if (tempX == totalMapSizeG)
-						tempX = 0;
-					else if (tempX == -1)
-						tempX = totalMapSizeG - 1;
-					if (mapCorner[tempX][tempY] == LOW)
-						mapCorner[x][y] = MEDIUM;
+					for (dx = -1; dx <= 1; ++dx) {
+						tempX = x + dx;
+						if (tempX == totalMapSizeG) {
+							tempX = 0;
+						} else if (tempX == -1) {
+							tempX = totalMapSizeG - 1;
+						}
+
+						if (mapCorner[tempX][tempY] == LOW) {
+							mapCorner[x][y] = MEDIUM;
+						}
+					}
 				}
 			} else if ((mapCorner[x][y] != LOW) && (mapCorner[x][y] != MEDIUM)) {
 				mapCorner[x][y] = MEDIUM; // should not happen anymore


### PR DESCRIPTION
There was a formatting error in the errorCorrection() method ran after generating the map. One of the iterating for loops was meant to be nested in the other, but instead it ran afterwards, causing some error conditions to get missed and causing a crash later in the program.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
