### PR TITLE
Correct value now being used for tileSet

### DIFF
--- a/engines/scumm/he/moonbase/map_main.cpp
+++ b/engines/scumm/he/moonbase/map_main.cpp
@@ -85,7 +85,7 @@ bool Map::generateMapWithInfo(uint8 generator, int seed, int mapSize, int tilese
 	case SPIFF_GEN:
 	{
 		SpiffGenerator spiff = SpiffGenerator(seed);
-		_generatedMap = spiff.generateMap(water, mapSize, energy, terrain);
+		_generatedMap = spiff.generateMap(water, tileset, mapSize, energy, terrain);
 		break;
 	}
 	default:

--- a/engines/scumm/he/moonbase/map_spiff.cpp
+++ b/engines/scumm/he/moonbase/map_spiff.cpp
@@ -32,7 +32,7 @@ SpiffGenerator::SpiffGenerator(int seed) {
 SpiffGenerator::~SpiffGenerator() {
 }
 
-MapFile *SpiffGenerator::generateMap(int water, int mapSize, int energy, int terrain) {
+MapFile *SpiffGenerator::generateMap(int water, int tileset, int mapSize, int energy, int terrain) {
 	totalMapSizeG = mapSize;
 	energyAmountG = (2 + energy) * totalMapSizeG * totalMapSizeG;
 
@@ -69,7 +69,7 @@ MapFile *SpiffGenerator::generateMap(int water, int mapSize, int energy, int ter
 	levelMap[MEDIUM] = 1;
 	levelMap[LOW] = 0;
 
-	mif.mapType = terrain;
+	mif.mapType = tileset;
 	Common::sprintf_s(mif.name, "Spiff %04X", _seed);
 
 	mif.dimension = totalMapSizeG;

--- a/engines/scumm/he/moonbase/map_spiff.h
+++ b/engines/scumm/he/moonbase/map_spiff.h
@@ -56,7 +56,7 @@ public:
 	SpiffGenerator(int seed);
 	~SpiffGenerator();
 
-	MapFile *generateMap(int water, int mapSize, int energy, int terrain);
+	MapFile *generateMap(int water, int tileset, int mapSize, int energy, int terrain);
 
 private:
 	int _seed;


### PR DESCRIPTION
The code was using the "terrain" parameter to determine the tileSet instead of the tileSet parameter.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
