### PR TITLE
SCUMM HE: Fix MD5 mismatch on Katton maps

### DIFF
--- a/engines/scumm/he/moonbase/map_katton.cpp
+++ b/engines/scumm/he/moonbase/map_katton.cpp
@@ -78,6 +78,7 @@ MapFile *KattonGenerator::generateMap(int water, int tileSet, int mapSize, int e
 	short int goodwater[1600][2];
 	// used in making energy
 	int maxnumclose = 0, maxnumfar = 0, maxnumrand = 0, smallmed = 0, goodplaceClose[300][2], goodplaceFar[300][2], numplaceClose, numplaceFar, placeFar[3], placeClose[2], counter, counterpools;
+	int stringiness, randomx, randomy;
 
 	//****************************************Make the basic landmass shapes.
 
@@ -86,23 +87,35 @@ MapFile *KattonGenerator::generateMap(int water, int tileSet, int mapSize, int e
 	for (i = 0; i < numsplotches; i++) {
 		length = (int)(((1 - waterpercent) / 6 * size * size) / numsplotches);
 		length = length + plusminus((int)(length / 2));
-		randomsplotch(length, 1 + plusminus(1), 2, getRandomNumber() % size, getRandomNumber() % size);
+		stringiness = 1 + plusminus(1);
+		randomx = getRandomNumber() % size;
+		randomy = getRandomNumber() % size;
+		randomsplotch(length, 1 + stringiness, 2, randomx, randomy);
 	}
 
 	for (i = 0; i < (int)numsplotches / 4; i++) {
 		length = (int)(((1 - waterpercent) / 3 * size * size) / numsplotches);
 		length = length + plusminus((int)(length / 4));
-		randomsplotch(length, 1 + plusminus(1), 1, getRandomNumber() % size, getRandomNumber() % size);
+		stringiness = 1 + plusminus(1);
+		randomx = getRandomNumber() % size;
+		randomy = getRandomNumber() % size;
+		randomsplotch(length, stringiness, 1, randomx, randomy);
 	}
 
 	for (i = 0; i < (int)numsplotches / 2; i++) {
 		length = (int)(size + plusminus((int)(size / 2)));
-		randomsplotch(length, 1 + plusminus(1), 0, getRandomNumber() % size, getRandomNumber() % size);
+		stringiness = 1 + plusminus(1);
+		randomx = getRandomNumber() % size;
+		randomy = getRandomNumber() % size;
+		randomsplotch(length, stringiness, 0, randomx, randomy);
 	}
 
 	for (i = 0; i < (int)waterpercent * size; i++) {
 		length = (int)(size + plusminus((int)(size / 2)));
-		randomsplotch(length, 1 + plusminus(1), 0, getRandomNumber() % size, getRandomNumber() % size);
+		stringiness = 1 + plusminus(1);
+		randomx = getRandomNumber() % size;
+		randomy = getRandomNumber() % size;
+		randomsplotch(length, stringiness, 0, randomx, randomy);
 	}
 
 	//****************************************Fatten up the landmasses
@@ -154,7 +167,9 @@ MapFile *KattonGenerator::generateMap(int water, int tileSet, int mapSize, int e
 			z = getRandomNumber() % multiplier + i * multiplier;
 			x = goodwater[z][0];
 			y = goodwater[z][1];
-			randomwater(size + plusminus(size / 2), getRandomNumber() % 3, x, y);
+			length = size + plusminus(size / 2);
+			stringiness = getRandomNumber() % 3;
+			randomwater(length, stringiness, x, y);
 		}
 	}
 


### PR DESCRIPTION
The random number generation will generate the same numbers from a given seed in a particular order. However, when passing function calls as parameters to another function, the order in which those parameter calls are made is undefined. If the code is compiled on different platforms using different compilers (e.g. macOS/clang vs linux/G++), this order can be different, which results in different random numbers being assigned to different variables.

The fix is to pull out the parameter function calls as variables so that the order in which the generated random numbers are assigned is the same, regardless of compiler/platform.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
